### PR TITLE
fix: pre-release public sharing and api contracts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
           npm run generate:openapi
           npm run generate:skills
-          node scripts/check-openapi-contract.mjs
+          npx tsx scripts/check-openapi-contract.ts
 
           git add package.json package-lock.json docs/openapi.json docs/openapi.yaml docs/skills.json
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -958,10 +958,8 @@
                   "value": {
                     "name": "Example Blog",
                     "domain": "example.com",
-                    "sharing": {
-                      "publicEnabled": true,
-                      "publicSlug": "example-blog"
-                    }
+                    "publicEnabled": true,
+                    "publicSlug": "example-blog"
                   }
                 }
               }
@@ -1114,10 +1112,7 @@
                   "summary": "Update a site",
                   "value": {
                     "name": "Example Blog",
-                    "sharing": {
-                      "publicEnabled": false,
-                      "publicSlug": null
-                    }
+                    "publicEnabled": false
                   }
                 }
               }
@@ -5871,14 +5866,22 @@
             "minLength": 1,
             "maxLength": 255
           },
-          "sharing": {
-            "$ref": "#/components/schemas/SharingSettings"
+          "publicEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether the public sharing link is enabled."
+          },
+          "publicSlug": {
+            "type": "string",
+            "maxLength": 120,
+            "description": "Optional public sharing slug when publicEnabled is true."
           }
-        }
+        },
+        "additionalProperties": false
       },
       "SiteUpdateInput": {
         "type": "object",
-        "description": "Partial update for site metadata and sharing settings.",
+        "description": "Partial update for site metadata and public sharing input fields.",
         "properties": {
           "name": {
             "type": "string",
@@ -5890,10 +5893,17 @@
             "minLength": 1,
             "maxLength": 255
           },
-          "sharing": {
-            "$ref": "#/components/schemas/SharingSettings"
+          "publicEnabled": {
+            "type": "boolean",
+            "description": "Whether the public sharing link is enabled."
+          },
+          "publicSlug": {
+            "type": "string",
+            "maxLength": 120,
+            "description": "Optional public sharing slug when publicEnabled is true."
           }
-        }
+        },
+        "additionalProperties": false
       },
       "SiteResponse": {
         "description": "Response envelope.",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -666,9 +666,8 @@ paths:
                 value:
                   name: Example Blog
                   domain: example.com
-                  sharing:
-                    publicEnabled: true
-                    publicSlug: example-blog
+                  publicEnabled: true
+                  publicSlug: example-blog
       responses:
         "201":
           description: Created site
@@ -744,9 +743,7 @@ paths:
                 summary: Update a site
                 value:
                   name: Example Blog
-                  sharing:
-                    publicEnabled: false
-                    publicSlug: null
+                  publicEnabled: false
       responses:
         "200":
           description: Successful response
@@ -3729,11 +3726,18 @@ components:
           type: string
           minLength: 1
           maxLength: 255
-        sharing:
-          $ref: "#/components/schemas/SharingSettings"
+        publicEnabled:
+          type: boolean
+          default: false
+          description: Whether the public sharing link is enabled.
+        publicSlug:
+          type: string
+          maxLength: 120
+          description: Optional public sharing slug when publicEnabled is true.
+      additionalProperties: false
     SiteUpdateInput:
       type: object
-      description: Partial update for site metadata and sharing settings.
+      description: Partial update for site metadata and public sharing input fields.
       properties:
         name:
           type: string
@@ -3743,8 +3747,14 @@ components:
           type: string
           minLength: 1
           maxLength: 255
-        sharing:
-          $ref: "#/components/schemas/SharingSettings"
+        publicEnabled:
+          type: boolean
+          description: Whether the public sharing link is enabled.
+        publicSlug:
+          type: string
+          maxLength: 120
+          description: Optional public sharing slug when publicEnabled is true.
+      additionalProperties: false
     SiteResponse:
       description: Response envelope.
       allOf:

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -887,17 +887,39 @@ function buildSchemas(): Record<string, unknown> {
       properties: {
         name: { type: "string", minLength: 1, maxLength: 120 },
         domain: { type: "string", minLength: 1, maxLength: 255 },
-        sharing: ref("SharingSettings"),
+        publicEnabled: {
+          type: "boolean",
+          default: false,
+          description: "Whether the public sharing link is enabled.",
+        },
+        publicSlug: {
+          type: "string",
+          maxLength: 120,
+          description:
+            "Optional public sharing slug when publicEnabled is true.",
+        },
       },
+      additionalProperties: false,
     },
     SiteUpdateInput: {
       type: "object",
-      description: "Partial update for site metadata and sharing settings.",
+      description:
+        "Partial update for site metadata and public sharing input fields.",
       properties: {
         name: { type: "string", minLength: 1, maxLength: 120 },
         domain: { type: "string", minLength: 1, maxLength: 255 },
-        sharing: ref("SharingSettings"),
+        publicEnabled: {
+          type: "boolean",
+          description: "Whether the public sharing link is enabled.",
+        },
+        publicSlug: {
+          type: "string",
+          maxLength: 120,
+          description:
+            "Optional public sharing slug when publicEnabled is true.",
+        },
       },
+      additionalProperties: false,
     },
     SiteResponse: envelope(ref("Site")),
     SiteListResponse: listEnvelope(ref("Site")),
@@ -3237,7 +3259,8 @@ function requestExamplesFor(schemaName: string | null) {
         value: {
           name: "Example Blog",
           domain: "example.com",
-          sharing: { publicEnabled: true, publicSlug: "example-blog" },
+          publicEnabled: true,
+          publicSlug: "example-blog",
         },
       },
     },
@@ -3246,7 +3269,7 @@ function requestExamplesFor(schemaName: string | null) {
         summary: "Update a site",
         value: {
           name: "Example Blog",
-          sharing: { publicEnabled: false, publicSlug: null },
+          publicEnabled: false,
         },
       },
     },

--- a/src/app/api/__tests__/edge-query-routes.test.ts
+++ b/src/app/api/__tests__/edge-query-routes.test.ts
@@ -6,7 +6,12 @@ import {
   PATCH as privatePATCH,
   POST as privatePOST,
 } from "@/app/api/private/[...segments]/route";
-import { GET as publicGET } from "@/app/api/public/[...segments]/route";
+import {
+  DELETE as publicDELETE,
+  GET as publicGET,
+  PATCH as publicPATCH,
+  POST as publicPOST,
+} from "@/app/api/public/[...segments]/route";
 import { handlePrivateAdmin } from "@/lib/edge/admin";
 import { handlePrivateArchive } from "@/lib/edge/archive-query";
 import { handlePrivateQuery, handlePublicQuery } from "@/lib/edge/query";
@@ -120,6 +125,22 @@ describe("edge query route wrappers", () => {
       new URL("https://app.test/api/public/site/overview"),
       ctx,
     );
+  });
+
+  it("routes public mutation methods to the public query handler for rejection", async () => {
+    const post = mockRuntime("/api/public/site/overview", "POST");
+    await publicPOST(post);
+
+    const patch = mockRuntime("/api/public/site/overview", "PATCH");
+    await publicPATCH(patch);
+
+    const del = mockRuntime("/api/public/site/overview", "DELETE");
+    await publicDELETE(del);
+
+    expect(handlePublicQueryMock).toHaveBeenCalledTimes(3);
+    expect(
+      handlePublicQueryMock.mock.calls.map((call) => call[0].method),
+    ).toEqual(["POST", "PATCH", "DELETE"]);
   });
 
   it("routes DELETE requests to the query handler", async () => {

--- a/src/app/api/public/[...segments]/route.ts
+++ b/src/app/api/public/[...segments]/route.ts
@@ -10,3 +10,15 @@ export async function GET(request: Request): Promise<Response> {
   } = await resolveEdgeRuntime(request);
   return handlePublicQuery(requestWithCf, env, url, ctx);
 }
+
+export async function POST(request: Request): Promise<Response> {
+  return GET(request);
+}
+
+export async function PATCH(request: Request): Promise<Response> {
+  return GET(request);
+}
+
+export async function DELETE(request: Request): Promise<Response> {
+  return GET(request);
+}

--- a/src/lib/dashboard/__tests__/client-request.test.ts
+++ b/src/lib/dashboard/__tests__/client-request.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchPrivateJson,
   fetchPrivateJsonMutate,
+  publicDashboardSiteId,
 } from "@/lib/dashboard/client-request";
 import { handleDemoRequest } from "@/lib/realtime/mock";
 
@@ -106,6 +107,62 @@ describe("dashboard client request helpers", () => {
       method: "GET",
       credentials: "include",
       signal,
+    });
+  });
+
+  it("rewrites public dashboard GET requests and omits credentials", async () => {
+    delete process.env.NEXT_PUBLIC_DEMO_MODE;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(jsonResponse({ ok: true, value: "public" })),
+      );
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchPrivateJson("/api/private/overview", {
+        siteId: publicDashboardSiteId("team site/one"),
+        from: 1,
+        to: 2,
+      }),
+    ).resolves.toEqual({ ok: true, value: "public" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/public/team%20site%2Fone/overview?from=1&to=2",
+      expect.objectContaining({
+        method: "GET",
+        credentials: "omit",
+      }),
+    );
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("siteId=");
+  });
+
+  it("keeps public and private request dedupe keys separate", async () => {
+    delete process.env.NEXT_PUBLIC_DEMO_MODE;
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(jsonResponse({ ok: true, value: "fresh" })),
+      );
+    globalThis.fetch = fetchMock;
+
+    await Promise.all([
+      fetchPrivateJson("/api/private/overview", { siteId: "site-1" }),
+      fetchPrivateJson("/api/private/overview", {
+        siteId: publicDashboardSiteId("site-1"),
+      }),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/private/overview?siteId=site-1",
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe("/api/public/site-1/overview");
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({
+      credentials: "include",
+    });
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({
+      credentials: "omit",
     });
   });
 

--- a/src/lib/edge/__tests__/api-v1-docs.test.ts
+++ b/src/lib/edge/__tests__/api-v1-docs.test.ts
@@ -173,6 +173,25 @@ describe("api v1 public docs", () => {
       "#/components/schemas/EventSearchRequest",
     );
 
+    expect(
+      spec.components.schemas.SiteCreateInput.properties?.sharing,
+    ).toBeUndefined();
+    expect(
+      spec.components.schemas.SiteUpdateInput.properties?.sharing,
+    ).toBeUndefined();
+    expect(spec.components.schemas.SiteCreateInput.properties).toEqual(
+      expect.objectContaining({
+        publicEnabled: expect.objectContaining({ type: "boolean" }),
+        publicSlug: expect.objectContaining({ type: "string" }),
+      }),
+    );
+    expect(spec.components.schemas.SiteUpdateInput.properties).toEqual(
+      expect.objectContaining({
+        publicEnabled: expect.objectContaining({ type: "boolean" }),
+        publicSlug: expect.objectContaining({ type: "string" }),
+      }),
+    );
+
     walk(spec.paths, (value) => {
       if (!value || typeof value !== "object" || !("requestBody" in value)) {
         return;

--- a/src/lib/edge/__tests__/api-v1.test.ts
+++ b/src/lib/edge/__tests__/api-v1.test.ts
@@ -1088,6 +1088,23 @@ describe("api v1 gateway", () => {
     expect(body.data.publicSlug).toBe("my-blog");
   });
 
+  it("disables sharing and clears the public slug via PATCH", async () => {
+    const { response } = await authed(
+      "/api/v1/sites/site-1/sharing",
+      [siteMatch("site-1", "Blog")],
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ publicEnabled: false, publicSlug: "old-blog" }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { publicEnabled: false, publicSlug: null },
+    });
+  });
+
   it("returns 409 when sharing slug conflicts", async () => {
     vi.mocked(ensurePublicSlugAvailable).mockResolvedValueOnce(false);
     const { response } = await authed(
@@ -1304,6 +1321,127 @@ describe("api v1 gateway", () => {
       { scopes_json: JSON.stringify(["site:read"]) },
     );
     expect(response.status).toBe(403);
+  });
+
+  it("prevents restricted keys from reading and updating unauthorized sites", async () => {
+    const get = await authed(
+      "/api/v1/sites/site-1",
+      [siteMatch("site-1", "Blog")],
+      undefined,
+      { site_ids_json: JSON.stringify(["site-2"]) },
+    );
+    expect(get.response.status).toBe(404);
+
+    const patch = await authed(
+      "/api/v1/sites/site-1",
+      [siteMatch("site-1", "Blog")],
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Blocked" }),
+      },
+      { site_ids_json: JSON.stringify(["site-2"]) },
+    );
+    expect(patch.response.status).toBe(404);
+  });
+
+  it("prevents restricted keys from reading unauthorized analytics families", async () => {
+    const overrides = { site_ids_json: JSON.stringify(["site-2"]) };
+    const cases = [
+      "/api/v1/sites/site-1/analytics/overview?from=2026-06-01T00:00:00Z&to=2026-06-02T00:00:00Z",
+      "/api/v1/sites/site-1/events?from=2026-06-01T00:00:00Z&to=2026-06-02T00:00:00Z",
+      "/api/v1/sites/site-1/sessions?from=2026-06-01T00:00:00Z&to=2026-06-02T00:00:00Z",
+      "/api/v1/sites/site-1/visitors?from=2026-06-01T00:00:00Z&to=2026-06-02T00:00:00Z",
+      "/api/v1/sites/site-1/realtime/snapshot",
+    ];
+
+    for (const path of cases) {
+      const { response } = await authed(
+        path,
+        [siteMatch("site-1", "Blog")],
+        undefined,
+        overrides,
+      );
+      expect(response.status, path).toBe(404);
+    }
+  });
+
+  it("does not let batch bypass site restrictions or missing scopes", async () => {
+    const restricted = await authed(
+      "/api/v1/batch",
+      [siteMatch("site-1", "Blog")],
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requests: [
+            {
+              id: "overview",
+              method: "GET",
+              path: "/api/v1/sites/site-1/analytics/overview",
+              query: {
+                from: "2026-06-01T00:00:00Z",
+                to: "2026-06-02T00:00:00Z",
+              },
+            },
+          ],
+        }),
+      },
+      { site_ids_json: JSON.stringify(["site-2"]) },
+    );
+    expect(restricted.response.status).toBe(200);
+    await expect(restricted.response.json()).resolves.toMatchObject({
+      data: { responses: [{ id: "overview", status: 404 }] },
+      meta: { partialFailure: true },
+    });
+
+    const noAnalytics = await authed(
+      "/api/v1/batch",
+      [siteMatch("site-1", "Blog")],
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requests: [
+            {
+              id: "overview",
+              method: "GET",
+              path: "/api/v1/sites/site-1/analytics/overview",
+            },
+          ],
+        }),
+      },
+      { scopes_json: JSON.stringify(["site:read"]) },
+    );
+    expect(noAnalytics.response.status).toBe(200);
+    await expect(noAnalytics.response.json()).resolves.toMatchObject({
+      data: { responses: [{ id: "overview", status: 403 }] },
+      meta: { partialFailure: true },
+    });
+
+    const writeAttempt = await authed(
+      "/api/v1/batch",
+      [siteMatch("site-1", "Blog")],
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          requests: [
+            {
+              id: "sharing",
+              method: "PATCH",
+              path: "/api/v1/sites/site-1/sharing",
+            },
+          ],
+        }),
+      },
+      { scopes_json: JSON.stringify(["site_config:read"]) },
+    );
+    expect(writeAttempt.response.status).toBe(200);
+    await expect(writeAttempt.response.json()).resolves.toMatchObject({
+      data: { responses: [{ id: "sharing", status: 400 }] },
+      meta: { partialFailure: true },
+    });
   });
 
   // ── additional coverage: analytics invalid interval ─────────────

--- a/src/lib/edge/__tests__/dashboard-cache.test.ts
+++ b/src/lib/edge/__tests__/dashboard-cache.test.ts
@@ -107,10 +107,11 @@ describe("edge dashboard cache wrapper", () => {
   });
 
   it("does not cache non-OK responses and tolerates cache failures", async () => {
+    const put = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("caches", {
       open: vi.fn().mockResolvedValue({
         match: vi.fn().mockRejectedValue(new Error("read failed")),
-        put: vi.fn().mockResolvedValue(undefined),
+        put,
       }),
     });
     const generate = vi
@@ -126,5 +127,6 @@ describe("edge dashboard cache wrapper", () => {
     expect(response.status).toBe(500);
     expect(await response.text()).toBe("nope");
     expect(response.headers.get("x-edge-cache")).toBeNull();
+    expect(put).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/edge/__tests__/query-core.test.ts
+++ b/src/lib/edge/__tests__/query-core.test.ts
@@ -17,6 +17,7 @@ import {
   emptyPerformanceRouteMetrics,
   eventPayloadFilterValueType,
   eventRecordOrderBy,
+  fetchPublicSite,
   finalizeDimensionBuckets,
   finalizeGeoDimensionBuckets,
   formatPageLabel,
@@ -62,6 +63,7 @@ import {
   withoutFilterKey,
   withoutGeoFilter,
 } from "@/lib/edge/query/core";
+import type { Env } from "@/lib/edge/types";
 
 const fixedNow = Date.UTC(2026, 4, 26, 8);
 
@@ -265,6 +267,65 @@ describe("edge query core parsers", () => {
         ]),
       ),
     ).toEqual([{ path: "/flags/enabled", operator: "ne", value: false }]);
+  });
+});
+
+describe("edge public site lookup", () => {
+  function envWithPublicSite(row: Record<string, unknown> | null) {
+    const first = vi.fn().mockResolvedValue(row);
+    const bind = vi.fn(() => ({ first }));
+    const prepare = vi.fn(() => ({ bind }));
+    const env = { DB: { prepare } } as unknown as Env;
+    return { env, prepare, bind, first };
+  }
+
+  it("requires enabled public sharing for slug lookup", async () => {
+    const { env, prepare, bind } = envWithPublicSite({
+      id: "site-1",
+      name: "Blog",
+      domain: "blog.test",
+    });
+
+    const site = await fetchPublicSite(
+      env,
+      new URL("https://edge.test/api/public/blog/site"),
+    );
+
+    expect(site).toMatchObject({ id: "site-1" });
+    expect(prepare).toHaveBeenCalledWith(
+      "SELECT id,name,domain FROM sites WHERE public_enabled=1 AND public_slug=? LIMIT 1",
+    );
+    expect(bind).toHaveBeenCalledWith("blog");
+  });
+
+  it("returns 404 for disabled, deleted, old, empty, or malformed slugs", async () => {
+    const { env, first } = envWithPublicSite(null);
+
+    for (const path of [
+      "/api/public/disabled/site",
+      "/api/public/old-slug/overview",
+      "/api/public/deleted/pages",
+    ]) {
+      const response = await fetchPublicSite(
+        env,
+        new URL(`https://edge.test${path}`),
+      );
+      expect(response).toBeInstanceOf(Response);
+      expect((response as Response).status, path).toBe(404);
+    }
+    expect(first).toHaveBeenCalledTimes(3);
+
+    const empty = await fetchPublicSite(
+      env,
+      new URL("https://edge.test/api/public/%20/site"),
+    );
+    expect((empty as Response).status).toBe(404);
+
+    const malformed = await fetchPublicSite(
+      env,
+      new URL("https://edge.test/api/public/%E0%A4%A/site"),
+    );
+    expect((malformed as Response).status).toBe(404);
   });
 });
 

--- a/src/lib/edge/__tests__/query-entry.test.ts
+++ b/src/lib/edge/__tests__/query-entry.test.ts
@@ -222,7 +222,7 @@ describe("edge query entry handlers", () => {
   });
 
   it("rejects unsupported public methods before public site lookup", async () => {
-    const edgeRequest = request("/api/public-sites/public/overview", {
+    const edgeRequest = request("/api/public/public/overview", {
       method: "POST",
     });
 
@@ -237,10 +237,10 @@ describe("edge query entry handlers", () => {
     expect(withDashboardCacheMock).not.toHaveBeenCalled();
   });
 
-  it("returns public site lookup responses without routing", async () => {
+  it("returns public site lookup responses without routing or cache lookup", async () => {
     const missing = new Response("missing", { status: 404 });
     fetchPublicSiteMock.mockResolvedValueOnce(missing);
-    const edgeRequest = request("/api/public-sites/missing/overview");
+    const edgeRequest = request("/api/public/missing/overview");
 
     const response = await handlePublicQuery(
       edgeRequest,
@@ -250,10 +250,11 @@ describe("edge query entry handlers", () => {
 
     expect(response).toBe(missing);
     expect(routeQueryMock).not.toHaveBeenCalled();
+    expect(withDashboardCacheMock).not.toHaveBeenCalled();
   });
 
   it("routes public paths after the slug through dashboard cache", async () => {
-    const edgeRequest = request("/api/public-sites/public/pages/top");
+    const edgeRequest = request("/api/public/public/pages");
     const url = new URL(edgeRequest.url);
     const ctx = {} as ExecutionContext;
 
@@ -273,7 +274,7 @@ describe("edge query entry handlers", () => {
     expect(routeQueryMock).toHaveBeenCalledWith(
       env,
       "site-public",
-      "pages/top",
+      "pages",
       url,
       { publicMode: true },
       edgeRequest,
@@ -281,7 +282,7 @@ describe("edge query entry handlers", () => {
   });
 
   it("wraps public site metadata responses with public cache options", async () => {
-    const edgeRequest = request("/api/public-sites/public/site");
+    const edgeRequest = request("/api/public/public/site");
     const url = new URL(edgeRequest.url);
     const ctx = {} as ExecutionContext;
 
@@ -307,5 +308,16 @@ describe("edge query entry handlers", () => {
       },
     );
     expect(routeQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("decodes public site slugs in metadata responses", async () => {
+    const edgeRequest = request("/api/public/team%20site/site");
+    const url = new URL(edgeRequest.url);
+
+    const response = await handlePublicQuery(edgeRequest, env, url);
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: { slug: "team site" },
+    });
   });
 });

--- a/src/lib/edge/__tests__/query-router.test.ts
+++ b/src/lib/edge/__tests__/query-router.test.ts
@@ -60,8 +60,8 @@ const handlerMocks = vi.hoisted(() => {
       handleBrowserVersionBreakdown: vi.fn(
         respond("browser-version-breakdown"),
       ),
-      handleClientCrossBreakdown: vi.fn(respond("client-cross-breakdown")),
       handleClientDimensionTrend: vi.fn(respond("client-dimension-trend")),
+      handleCrossBreakdown: vi.fn(respond("client-cross-breakdown")),
       handleReferrerDimensionTrend: vi.fn(respond("referrer-dimension-trend")),
       handleReferrerRadar: vi.fn(respond("referrer-radar")),
       handleUtmDimensionTrend: vi.fn(respond("utm-dimension-trend")),
@@ -116,6 +116,72 @@ describe("edge query router", () => {
       undefined,
     );
     expect(handlerMocks.core.notFound).not.toHaveBeenCalled();
+  });
+
+  it("routes the public sharing query allowlist", async () => {
+    const publicPaths = [
+      "overview",
+      "trend",
+      "pages",
+      "pages-dashboard",
+      "referrers",
+      "retention",
+      "performance",
+      "overview-geo-points",
+      "overview-geo-country",
+      "overview-source-domain",
+      "overview-source-link",
+      "overview-client-browser",
+      "overview-client-device-type",
+      "browser-trend",
+      "browser-engine-trend",
+      "browser-version-breakdown",
+      "browser-cross-breakdown",
+      "browser-radar",
+      "referrer-radar",
+      "referrer-dimension-trend",
+      "client-dimension-trend",
+      "client-cross-breakdown",
+      "utm-source",
+      "utm-medium",
+      "utm-campaign",
+      "utm-term",
+      "utm-content",
+      "utm-dimension-trend",
+      "page-query",
+      "page-hash",
+      "event-types",
+    ];
+
+    for (const path of publicPaths) {
+      const response = await route(path, true);
+      expect(response.status, path).toBe(200);
+    }
+  });
+
+  it("blocks sensitive detail queries in public mode", async () => {
+    const blockedPaths = [
+      "funnels",
+      "sessions",
+      "session-detail",
+      "visitors",
+      "visitor-detail",
+      "events-records",
+      "event-record-detail",
+    ];
+
+    for (const path of blockedPaths) {
+      const response = await route(path, true);
+      expect(response.status, path).toBe(404);
+    }
+
+    expect(handlerMocks.funnels.handleFunnel).not.toHaveBeenCalled();
+    expect(handlerMocks.journeys.handleSessions).not.toHaveBeenCalled();
+    expect(handlerMocks.journeys.handleSessionDetail).not.toHaveBeenCalled();
+    expect(handlerMocks.journeys.handleVisitors).not.toHaveBeenCalled();
+    expect(handlerMocks.journeys.handleVisitorDetail).not.toHaveBeenCalled();
+    expect(handlerMocks.events.handleEventsRecords).not.toHaveBeenCalled();
+    expect(handlerMocks.events.handleEventRecordDetail).not.toHaveBeenCalled();
   });
 
   it("blocks all non-public routes before dispatching handlers", async () => {

--- a/src/schemas/__tests__/analytics.test.ts
+++ b/src/schemas/__tests__/analytics.test.ts
@@ -469,22 +469,48 @@ describe("BatchInputSchema", () => {
   it("accepts valid batch input", () => {
     expect(
       BatchInputSchema.safeParse({
-        from: 1700000000000,
-        to: 1700086400000,
-        queries: [{ queryName: "overview" }],
+        requests: [
+          {
+            id: "overview",
+            method: "GET",
+            path: "/api/v1/sites/site-1/analytics/overview",
+            query: { preset: "last_7_days" },
+          },
+        ],
       }).success,
     ).toBe(true);
   });
 
-  it("rejects empty queries array", () => {
-    expect(BatchInputSchema.safeParse({ queries: [] }).success).toBe(false);
+  it("rejects empty requests array", () => {
+    expect(BatchInputSchema.safeParse({ requests: [] }).success).toBe(false);
   });
 
-  it("rejects more than 10 queries", () => {
-    const queries = Array.from({ length: 11 }, () => ({
-      queryName: "overview",
+  it("rejects more than 20 requests", () => {
+    const requests = Array.from({ length: 21 }, (_, index) => ({
+      id: `overview-${index}`,
+      method: "GET",
+      path: "/api/v1/sites/site-1/analytics/overview",
     }));
-    expect(BatchInputSchema.safeParse({ queries }).success).toBe(false);
+    expect(BatchInputSchema.safeParse({ requests }).success).toBe(false);
+  });
+
+  it("rejects non-GET subrequests and non-v1 paths", () => {
+    expect(
+      BatchInputSchema.safeParse({
+        requests: [
+          {
+            id: "bad",
+            method: "POST",
+            path: "/api/v1/sites/site-1/analytics/overview",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      BatchInputSchema.safeParse({
+        requests: [{ id: "bad", method: "GET", path: "/collect/event" }],
+      }).success,
+    ).toBe(false);
   });
 });
 
@@ -496,16 +522,13 @@ describe("BatchResponseSchema", () => {
         requestId: "r",
         timestamp: "t",
         data: {
-          partialFailure: true,
-          results: [
-            { queryName: "overview", ok: true, status: 200, data: {} },
-            {
-              queryName: "trend",
-              ok: false,
-              status: 400,
-              error: { code: "bad_request", message: "Missing from" },
-            },
+          responses: [
+            { id: "overview", status: 200, body: { data: {} } },
+            { id: "trend", status: 400, body: { error: {} } },
           ],
+        },
+        meta: {
+          partialFailure: true,
         },
       }).success,
     ).toBe(true);

--- a/src/schemas/analytics.ts
+++ b/src/schemas/analytics.ts
@@ -738,51 +738,46 @@ export const GeoPointsResponseSchema = createEnvelopeSchema(
 
 // Batch response
 export const BatchResultItemSchema = z.object({
-  queryName: z.string(),
-  ok: z.boolean(),
+  id: z.string(),
   status: z.number().describe("HTTP status code of the sub-query response"),
-  data: z
+  body: z
     .unknown()
-    .optional()
-    .describe("Query result data (shape varies by queryName)"),
-  error: z
-    .object({
-      code: z.string(),
-      message: z.string(),
-    })
-    .optional()
-    .describe("Present only if this individual query failed"),
+    .nullable()
+    .describe("Subrequest response body, or null for empty responses"),
 });
 
 export const BatchResponseSchema = createEnvelopeSchema(
   z.object({
+    responses: z.array(BatchResultItemSchema),
+  }),
+).extend({
+  meta: z.object({
     partialFailure: z
       .boolean()
       .describe("True if any sub-query returned a non-200 status"),
-    results: z.array(BatchResultItemSchema),
   }),
-);
+});
 
 export const BatchInputSchema = z
   .object({
-    from: z.number().int().optional(),
-    to: z.number().int().optional(),
-    interval: IntervalSchema.optional(),
-    timeZone: z.string().optional(),
-    queries: z
+    requests: z
       .array(
         z
           .object({
-            queryName: z.string(),
-            from: z.number().int().optional(),
-            to: z.number().int().optional(),
-            interval: IntervalSchema.optional(),
-            limit: z.number().int().optional(),
+            id: z.string(),
+            method: z.literal("GET"),
+            path: z.string().startsWith("/api/v1/"),
+            query: z
+              .record(
+                z.string(),
+                z.union([z.string(), z.number(), z.boolean(), z.null()]),
+              )
+              .optional(),
           })
           .strict(),
       )
       .min(1)
-      .max(10),
+      .max(20),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Fix release workflow OpenAPI contract check to call the current TypeScript script through `tsx`.
- Align API v1 site create/update OpenAPI docs with the implemented top-level public sharing fields.
- Align batch schemas with the current `/api/v1/batch` request/response shape.
- Add regression coverage for public sharing routes, cache/auth ordering, public client requests, public query allowlist, and API key/batch authorization boundaries.

## Validation
- `npm ci`
- `npx vitest run src/schemas/__tests__/analytics.test.ts src/app/api/__tests__/edge-query-routes.test.ts src/lib/edge/__tests__/query-entry.test.ts src/lib/edge/__tests__/query-router.test.ts src/lib/edge/__tests__/dashboard-cache.test.ts src/lib/dashboard/__tests__/client-request.test.ts src/lib/edge/__tests__/query-core.test.ts src/lib/edge/__tests__/api-v1.test.ts src/lib/edge/__tests__/api-v1-docs.test.ts`
- `npm run check`
- `npm run check:openapi`

## Notes
- `npm run cf:deploy:dry-run` is blocked by deployment configuration: `wrangler.toml` has `database_id = "YOUR_D1_ID"` for the default remote D1 binding, and Wrangler rejects it as an invalid UUID. A retry with a temporary process-only `MAIN_SECRET` passed the secret check and stopped at that D1 id validation.